### PR TITLE
FX-01-AgregarCategoría

### DIFF
--- a/ApiControllers/CategoriasAPIController.cs
+++ b/ApiControllers/CategoriasAPIController.cs
@@ -58,7 +58,7 @@ namespace d_angela_variedades.API
         }
 
         [HttpPost]
-        public async Task<ActionResult<Categoria>> Post([FromBody] Categoria nombreCategoria)
+        public async Task<ActionResult<Categoria>> Post([FromBody] CategoriaEditarDTO nombreCategoria)
         {
             var usuarioId = serviciosUsuarios.ObtenerUsuarioId();
 

--- a/Interfaces/ICategoriasRepositorio.cs
+++ b/Interfaces/ICategoriasRepositorio.cs
@@ -6,7 +6,7 @@ namespace d_angela_variedades.Interfaces
     public interface ICategoriasRepositorio
     {
         Task<List<Categoria>> ListadoDeCategorias(int empresaUsuarioId);
-        Task<Categoria> AgregarCategoria(Categoria nombreCategoria, int empresaUsuarioId);
+        Task<Categoria> AgregarCategoria(CategoriaEditarDTO nombreCategoria, int empresaUsuarioId);
         Task<bool> Save();
         Task<Categoria> ObtenerCategoria(int categoriaId, int empresaCategoriaId);
         Task<bool> EditarCategoria(CategoriaEditarDTO categoria, int categoriaId, int empresaUsuarioId);

--- a/Repositorio/CategoriaRepositorio.cs
+++ b/Repositorio/CategoriaRepositorio.cs
@@ -18,7 +18,7 @@ namespace d_angela_variedades.Repositorio
             this.usuariosRepositorio = usuariosRepositorio;
         }
 
-        public async Task<Categoria> AgregarCategoria(Categoria nombreCategoria, int empresaUsuarioId)
+        public async Task<Categoria> AgregarCategoria(CategoriaEditarDTO nombreCategoria, int empresaUsuarioId)
         { 
             var nuevaCategoria = new Categoria();
 

--- a/wwwroot/js/categorias.js
+++ b/wwwroot/js/categorias.js
@@ -15,6 +15,7 @@ async function guardarCategoria(categoria) {
 
         const object = {
             "Nombre": nombreCategoria
+            
         };
 
         const data = JSON.stringify(object);


### PR DESCRIPTION
He reparado el bug que surgía al agregar una categoría, se trataba de que había un campo requerido que no se estaba enviando al backend, esto sucedió porque estaba usando la entidad misma como tipo de dato para recibir los datos desde el front end, y la entidad tiene un campo que no se envía ya que no interactúa con el proceso de envío de la categoría. Lo que hice fue utilizar el DTO de categoría que había creado anteriormente para editar las categorías.